### PR TITLE
docs: add intro to markdown

### DIFF
--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -1,0 +1,34 @@
+# About Markdown
+
+Markdown is the most commonly used [Lightweight Markup Language](https://en.wikipedia.org/wiki/Lightweight_markup_language).
+
+It allows to describe a document presentation and content in an highly simple an human readable way.
+
+Like any source code, a Markdown file (with a `.md` extension) is just a simple text file following a pre-defined syntax. You can therefor edit it using any text file editor. Only the presentation (converting the code into HTML, PDF, etc.) requires specific tools.
+
+## Basic Syntax
+
+All Markdown tools support the same basic syntax.
+
+Refer to:
+
+- [markdownguide.org/cheat-sheet/](https://www.markdownguide.org/cheat-sheet/) for a quick overview
+- [markdownguide.org/basic-syntax/](https://www.markdownguide.org/basic-syntax/) for a more detailed guide
+- [Github docs - Basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
+
+## Mardown in Github
+
+Github allow to use Markdown pretty much everywhere, including:
+
+- in issues and comments
+- in Pull Requests
+- files (all files with an .md extension are automatically rendered)
+
+It defines its own extensions of basic markdown syntax, with:
+
+- [Github Flavored Markdown](https://github.github.com/gfm/), for more advanced presentations capabilities (like tables or collapsable sections)
+- [autolinked references](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls) to refer to Github contents (like issues, pull requests, and commits) more easily
+- [diagrams](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams)
+- and more.
+
+For more information, refer directly to [Github documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting).


### PR DESCRIPTION
Add a simplistic introduction to markdown in the docs directory to serve as a reference.

Suggestions are welcomed, but **keep it simple** :pray: 