### PR TITLE
fix(DecisionFramework): better encourage draft PR

### DIFF
--- a/DecisionFramework/README.md
+++ b/DecisionFramework/README.md
@@ -98,7 +98,11 @@ Use [`RFC-XXXX-template.md`](./templates/RFC-XXXX-template.md) to help you bette
 1. All decisions impacting staff members and the community in the long term should be recorded.
 1. All recorded decisions have to be linked to a problem they solve. If you can't clearly state this problem, you can't record a decision.
 1. If the decision won't last more than a few weeks, you don't need to record it using one of our templates. You can just open an issue or write an informal note instead for more efficiency.
-1. Never hesistate to share! If you identified a problem, but aren't sure about the solution or how to address it, just write a draft to start the discussion (i.e. put what little following the most appropriate template, and create a [Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)).
+1. **Never hesitate to share!** If you identified a problem, but aren't sure about the solution or how to address it, just write a draft to start the discussion (i.e. put what little following the most appropriate template, and create a [Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)).
+
+> **DO create a draft PR as soon as possible.**
+>
+> Even if you just started to write some documents in a dedicated branch, a [Draft Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests) will provide a central place for people to ask questions and discuss any related matters, instead of spreading the information over several (sometimes unrelated) issues and discussions.
 
 ### Questions to ask yourself
 


### PR DESCRIPTION
## Content

Add a new paragraph to the Decision Framework > _"When should you record a decision?"_ section to encourage contributors to open a Draft PR as soon as they started to write some documents in a git branch.

## Goal

Discuss and clarify when and how we should start discussing a future decision.

## Context

As we started to write complex RFCs and related documents to define the basis for the new blindnet devkit, the discussion spread over several unrelated issues and discussions, as the writing occurred in a dedicated branch without a related PR or issue.

To quote @milstan when talking about the schema in https://github.com/blindnet-io/communication-management/issues/95#issuecomment-1139405780:

> when we have a first version, clearly written, with at least some thinking well elaborated, and questions well layed out, I can make draft pull request (This is my understanding of Open Org).